### PR TITLE
Add a note for learners without needed packages installed

### DIFF
--- a/episodes/02-better-start-version-control.md
+++ b/episodes/02-better-start-version-control.md
@@ -641,6 +641,10 @@ In both cases there will be another error:
 Error in Date() : could not find function "Date"
 ```
 
+**Note:** If you don't have both `lubridate` and `jsonlite` already installed, you may get an error notifying you of the missing packages.
+For now, go ahead and install them using either the `install.packages()` command or by selecting "install" in the alert banner in the Source pane.
+We'll cover a reproducible approach to package installation in Episode 3.
+
 :::::::::::::::::::::::::::: challenge
 
 - Where in the code is the problem? Which line?


### PR DESCRIPTION
Some users will get a different error at this point because they don't have the needed packages installed (as opposed to the provided output of not having them loaded). There's an instructor's note on this, but I think it's important to include a note in the main body of the text for learners working through the lesson independently.