### PR TITLE
Update command for listing project directory contents

### DIFF
--- a/episodes/03-reproducible-dev-environment.md
+++ b/episodes/03-reproducible-dev-environment.md
@@ -157,8 +157,8 @@ renv::init()
 
 If you list the contents of the project directory, you should see something like:
 
-```bash
-$ tree -a -L 5
+```r
+fs::dir_tree()
 ```
 
 ```output


### PR DESCRIPTION
changed the Linux tree command in the example for R's fs::dir_tree() 

Many of the learners did not have the tree command available when we first tested the lesson